### PR TITLE
fix: adjust font size for expected range display in forecast content

### DIFF
--- a/frontend/src/components/map/LeafletMap.tsx
+++ b/frontend/src/components/map/LeafletMap.tsx
@@ -2141,7 +2141,7 @@ function ForecastContent({
                 <div className="text-xs font-medium text-slate-500"><Pm25Unit /></div>
               </div>
               <div className="min-w-0">
-                <div className="whitespace-nowrap text-[04px] font-semibold uppercase tracking-[0.04em] text-slate-500 sm:text-[11px]">Expected <br></br> Range</div>
+                <div className="whitespace-nowrap text-[10px] font-semibold uppercase tracking-[0.04em] text-slate-500 sm:text-[11px]">Expected <br></br> Range</div>
                 <div className="mt-1 whitespace-nowrap text-[clamp(0.75rem,2.7vw,0.875rem)] font-semibold text-slate-950">
                   {formatForecastMetric(active.pm2_5_low, 1)} - {formatForecastMetric(active.pm2_5_high, 1)}
                 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the display size of the "Expected Range" label in forecast metric cards. The label now renders at an appropriate size for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->